### PR TITLE
Add support for in-shell execution

### DIFF
--- a/test_zscroll.py
+++ b/test_zscroll.py
@@ -40,6 +40,14 @@ def test_shell_output(command, result):
     assert z.shell_output(command, False) == result
 
 
+@pytest.mark.parametrize('command,result', [
+    ('echo $(echo test)', 'test'),
+    ('false', '')
+])
+def test_eval_shell_output(command, result):
+    assert z.shell_output(command, True) == result
+
+
 @pytest.mark.parametrize('arg_string,result', [
     # basic case with both fullwidth and halfwidth characters
     ('-l 8 -b "b: " -a " :a" -p "|" -d 0.0000001 "aaいuえoわし"',

--- a/test_zscroll.py
+++ b/test_zscroll.py
@@ -37,7 +37,7 @@ def test_make_visual_len(string, new_length, new_string):
     ('false', ''),
 ])
 def test_shell_output(command, result):
-    assert z.shell_output(command) == result
+    assert z.shell_output(command, False) == result
 
 
 @pytest.mark.parametrize('arg_string,result', [

--- a/zscroll
+++ b/zscroll
@@ -164,30 +164,17 @@ parser.add_argument(
 )
 
 parser.add_argument(
-    '-i',
-    '--insecure-match',
+    '-e',
+    '--eval-in-shell',
     type=str_to_bool,
     default=False,
     help="""
-         executes the commands in -M/--match-command and -m/--match-text in shell
-         which allows them to use environment variables (like $PWD)
-         or execute other scripts (e.g. "$(/path/to/script)");
-         note that this could lead to unwanted command injection,
-         so only use it when it's really necessary (default: false)
-         """
-)
-
-parser.add_argument(
-    '-I',
-    '--insecure-command',
-    type=str_to_bool,
-    default=False,
-    help="""
-         executes the positional argument in shell (-u/--update-check must be true too)
-         which allows it to use environment variables (like $PWD)
-         or execute other scripts (e.g. "$(/path/to/script)");
-         note that this could lead to unwanted command injection,
-         so only use it when it's really necessary (default: false)
+         executes -M/--match-command, -m/--match-text and the positional argument 
+         in shell (-u/--update-check must be true too) which allows the use of
+         environment variables (like $PWD) in it or execute other scripts
+         along with other commands (e.g. 'echo $(/path/to/script)'); 
+         watch out to quote the commands right to prevent unwanted command injection
+         (default: false)
          """
 )
 
@@ -295,7 +282,7 @@ def update_check():
     :rtype: bool
     """
     global scroll_text
-    compare_text = shell_output(args.scroll_text, args.insecure_command)
+    compare_text = shell_output(args.scroll_text, args.eval_in_shell)
     if scroll_text != compare_text:
         scroll_text = compare_text
         return True
@@ -323,11 +310,11 @@ def match_update_args():
     :rtype: bool
     """
     match_args = None
-    search_text = shell_output(args.match_command[0], args.insecure_match)
+    search_text = shell_output(args.match_command[0], args.eval_in_shell)
     text_was_updated = False
     for i in range(len(args.match_text)):
         if len(args.match_command) > 1 and i > 0:
-            search_text = shell_output(args.match_command[i], args.insecure_match)
+            search_text = shell_output(args.match_command[i], args.eval_in_shell)
         if search(args.match_text[i][0], search_text):
             match_args = parser.parse_args(split(args.match_text[i][1]))
             text_was_updated = (

--- a/zscroll
+++ b/zscroll
@@ -169,7 +169,7 @@ parser.add_argument(
     type=str_to_bool,
     default=False,
     help="""
-         executes -M/--match-command, -m/--match-text and the positional argument 
+         executes -M/--match-command and the positional argument 
          in shell (-u/--update-check must be true too) which allows the use of
          environment variables (like $PWD) in it or execute other scripts
          along with other commands (e.g. 'echo $(/path/to/script)'); 

--- a/zscroll
+++ b/zscroll
@@ -164,6 +164,34 @@ parser.add_argument(
 )
 
 parser.add_argument(
+    '-i',
+    '--insecure-match',
+    type=str_to_bool,
+    default=False,
+    help="""
+         executes the commands in -M/--match-command and -m/--match-text in shell
+         which allows them to use environment variables (like $PWD)
+         or execute other scripts (e.g. "$(/path/to/script)");
+         note that this could lead to unwanted command injection,
+         so only use it when it's really necessary (default: false)
+         """
+)
+
+parser.add_argument(
+    '-I',
+    '--insecure-command',
+    type=str_to_bool,
+    default=False,
+    help="""
+         executes the positional argument in shell (-u/--update-check must be true too)
+         which allows it to use environment variables (like $PWD)
+         or execute other scripts (e.g. "$(/path/to/script)");
+         note that this could lead to unwanted command injection,
+         so only use it when it's really necessary (default: false)
+         """
+)
+
+parser.add_argument(
     '-n',
     '--newline',
     type=str_to_bool,
@@ -238,7 +266,7 @@ def make_visual_len(desired_visual_length, text):
     return altered_text
 
 
-def shell_output(command):
+def shell_output(command, shell):
     """Get the output of a shell command as a string.
 
     If the command fails, return "".  This is useful in certain cases where a
@@ -254,7 +282,7 @@ def shell_output(command):
     """
     try:
         return (
-            check_output(split(command)).decode(encoding='UTF-8').rstrip('\n')
+            check_output(command if shell else split(command), shell=shell).decode(encoding='UTF-8').rstrip('\n')
         )
     except CalledProcessError:
         return ''
@@ -267,7 +295,7 @@ def update_check():
     :rtype: bool
     """
     global scroll_text
-    compare_text = shell_output(args.scroll_text)
+    compare_text = shell_output(args.scroll_text, args.insecure_command)
     if scroll_text != compare_text:
         scroll_text = compare_text
         return True
@@ -295,11 +323,11 @@ def match_update_args():
     :rtype: bool
     """
     match_args = None
-    search_text = shell_output(args.match_command[0])
+    search_text = shell_output(args.match_command[0], args.insecure_match)
     text_was_updated = False
     for i in range(len(args.match_text)):
         if len(args.match_command) > 1 and i > 0:
-            search_text = shell_output(args.match_command[i])
+            search_text = shell_output(args.match_command[i], args.insecure_match)
         if search(args.match_text[i][0], search_text):
             match_args = parser.parse_args(split(args.match_text[i][1]))
             text_was_updated = (

--- a/zscroll.1
+++ b/zscroll.1
@@ -47,6 +47,12 @@ Specify that the positional argument refers to a command that should be run to o
 \fB-U TIME\fR, \fB --update-interval=TIME\fR
 Specify the time in seconds to wait in between running update checking commands. This applies to the positional argument when -u/--update-check is specified and to commands specified with -M/--match-command. This may be useful if the scrolling text only needs to be updated infrequently or if continuously running the update checking command(s) is resource intensive. (default: 0)
 .TP
+\fb-i BOOL\fR, \fB --insecure-match=BOOL\fR
+Executes the commands in -M/--match-command and -m/--match-text in shell which allows them to use environment variables (like $PWD) or execute other scripts (e.g. "$(/path/to/script)"). Note that this could lead to unwanted command injection, so only use it when it's really necessary (default: false)
+.TP
+\fb-I BOOL\fR, \fB --insecure-command=BOOL\fR
+Executes the positional argument in shell (-u/--update-check must be true too) which allows it to use environment variables (like $PWD) or execute other scripts (e.g. "$(/path/to/script)"). Note that this could lead to unwanted command injection, so only use it when it's really necessary (default: false)
+.TP
 \fB-n BOOL\fR, \fB --newline=BOOL\fR
 Add a newline after every update/step (may be necessary for use with panels). Takes no argument. (default: true)
 .TP

--- a/zscroll.1
+++ b/zscroll.1
@@ -47,11 +47,8 @@ Specify that the positional argument refers to a command that should be run to o
 \fB-U TIME\fR, \fB --update-interval=TIME\fR
 Specify the time in seconds to wait in between running update checking commands. This applies to the positional argument when -u/--update-check is specified and to commands specified with -M/--match-command. This may be useful if the scrolling text only needs to be updated infrequently or if continuously running the update checking command(s) is resource intensive. (default: 0)
 .TP
-\fB-i BOOL\fR, \fB --insecure-match=BOOL\fR
-Executes the commands in -M/--match-command and -m/--match-text in shell which allows them to use environment variables (like $PWD) or execute other scripts (e.g. "$(/path/to/script)"). Note that this could lead to unwanted command injection, so only use it when it's really necessary (default: false)
-.TP
-\fB-I BOOL\fR, \fB --insecure-command=BOOL\fR
-Executes the positional argument in shell (-u/--update-check must be true too) which allows it to use environment variables (like $PWD) or execute other scripts (e.g. "$(/path/to/script)"). Note that this could lead to unwanted command injection, so only use it when it's really necessary (default: false)
+\fB-e BOOL\fR, \fB --eval-in-shell=BOOL\fR
+Executes -M/--match-command, -m/--match-text and the positional argument in shell (-u/--update-check must be true too) which allows the use of environment variables (like $PWD) in it or execute other scripts along with other commands (e.g. 'echo $(/path/to/script)'). Watch out to quote the commands right to prevent unwanted command injection. See https://docs.python.org/3/library/subprocess.html#security-considerations for further shell security related information. (default: false)
 .TP
 \fB-n BOOL\fR, \fB --newline=BOOL\fR
 Add a newline after every update/step (may be necessary for use with panels). Takes no argument. (default: true)
@@ -72,6 +69,10 @@ $ zscroll -n false -u true -b "playing: " "mpc current"
 You can also pipe into zscroll:
 .br
 $ xtitle | zscroll -l 60
+
+Full shell instructions can be passed too:
+.br
+$ zscroll -u true -e true 'echo Unix Time: $(date +%s)'
 
 An example that will stop scrolling the song when it is paused and change the before padding text depending on the state of the song:
 .br

--- a/zscroll.1
+++ b/zscroll.1
@@ -48,7 +48,7 @@ Specify that the positional argument refers to a command that should be run to o
 Specify the time in seconds to wait in between running update checking commands. This applies to the positional argument when -u/--update-check is specified and to commands specified with -M/--match-command. This may be useful if the scrolling text only needs to be updated infrequently or if continuously running the update checking command(s) is resource intensive. (default: 0)
 .TP
 \fB-e BOOL\fR, \fB --eval-in-shell=BOOL\fR
-Executes -M/--match-command, -m/--match-text and the positional argument in shell (-u/--update-check must be true too) which allows the use of environment variables (like $PWD) in it or execute other scripts along with other commands (e.g. 'echo $(/path/to/script)'). Watch out to quote the commands right to prevent unwanted command injection. See https://docs.python.org/3/library/subprocess.html#security-considerations for further shell security related information. (default: false)
+Executes -M/--match-command and the positional argument in shell (-u/--update-check must be true too) which allows the use of environment variables (like $PWD) in it or execute other scripts along with other commands (e.g. 'echo $(/path/to/script)'). Watch out to quote the commands right to prevent unwanted command injection. See https://docs.python.org/3/library/subprocess.html#security-considerations for further shell security related information. (default: false)
 .TP
 \fB-n BOOL\fR, \fB --newline=BOOL\fR
 Add a newline after every update/step (may be necessary for use with panels). Takes no argument. (default: true)

--- a/zscroll.1
+++ b/zscroll.1
@@ -47,10 +47,10 @@ Specify that the positional argument refers to a command that should be run to o
 \fB-U TIME\fR, \fB --update-interval=TIME\fR
 Specify the time in seconds to wait in between running update checking commands. This applies to the positional argument when -u/--update-check is specified and to commands specified with -M/--match-command. This may be useful if the scrolling text only needs to be updated infrequently or if continuously running the update checking command(s) is resource intensive. (default: 0)
 .TP
-\fb-i BOOL\fR, \fB --insecure-match=BOOL\fR
+\fB-i BOOL\fR, \fB --insecure-match=BOOL\fR
 Executes the commands in -M/--match-command and -m/--match-text in shell which allows them to use environment variables (like $PWD) or execute other scripts (e.g. "$(/path/to/script)"). Note that this could lead to unwanted command injection, so only use it when it's really necessary (default: false)
 .TP
-\fb-I BOOL\fR, \fB --insecure-command=BOOL\fR
+\fB-I BOOL\fR, \fB --insecure-command=BOOL\fR
 Executes the positional argument in shell (-u/--update-check must be true too) which allows it to use environment variables (like $PWD) or execute other scripts (e.g. "$(/path/to/script)"). Note that this could lead to unwanted command injection, so only use it when it's really necessary (default: false)
 .TP
 \fB-n BOOL\fR, \fB --newline=BOOL\fR


### PR DESCRIPTION
This adds 2 new arguments, `-i` / `--insecure-match` and `-I` / `--insecure-command`.
With `-i`, everything given in `--match-command` and `--match-text` will be executed in shell which allows the use of environment variables (like `$PWD`) or other shell related actions (e.g. call of another script) in it. For `-I` it's the same, except that not the commands in `--match-command` and `--match-text` are executed in shell, but the positional argument.

Execution in shell could lead to unwanted command injection because this should only be used if necessary (which led to the naming of the new arguments)