### PR TITLE
add --always-reprint flag

### DIFF
--- a/zscroll
+++ b/zscroll
@@ -39,6 +39,13 @@ parser.add_argument(
 )
 
 parser.add_argument(
+    '--always-reprint',
+    type=str_to_bool,
+    default=False,
+    help="reprint text every delay even if it hasn't changed"
+)
+
+parser.add_argument(
     '-l',
     '--length',
     type=int,
@@ -425,7 +432,7 @@ def zscroll(lines=0):
             needs_scrolling,
             (last_hidden_was_wide or next_hidden_is_wide),
         )
-        if args.scroll and needs_scrolling or should_restart_printing:
+        if args.always_reprint or (args.scroll and needs_scrolling) or should_restart_printing:
             print_text(display_text)
             should_restart_printing = False
         if args.scroll and needs_scrolling:

--- a/zscroll.1
+++ b/zscroll.1
@@ -55,6 +55,8 @@ Add a newline after every update/step (may be necessary for use with panels). Ta
 .TP
 \fB\-t TIME\fR, \fB \-\-timeout=TIME\fR
 Time in seconds to run before closing. An argument of zero implies infinite duration. (default: 0)
+\fB \-\-always\-reprint=BOOL\fR
+Whether to reprint unchanged text after the specified delay (default: false)
 .SH EXAMPLES
 These examples are meant for testing in the terminal (remove the "-n false" for use with panels).
 


### PR DESCRIPTION
When doing post-processing on each line from zscroll, I found it to be useful to get a new line every <delay> seconds, regardless of whether the text had been changed. To that end, I added a --always-reprint flag to bypass these checks.
